### PR TITLE
Separate strict versions from 'init' and 'tail'

### DIFF
--- a/packages/array/init.ts
+++ b/packages/array/init.ts
@@ -3,4 +3,11 @@
  * @param array Input array
  * @returns All but last items of `array`
  */
-export const init = <Init extends any[]>(array: readonly [...Init, any]): Init => array.slice(0, -1) as any
+export const initStrict = <Init extends any[]>(array: readonly [...Init, any]): Init => array.slice(0, -1) as any
+
+/**
+ * Get all but last items of an array
+ * @param array Input array
+ * @returns All but last items of `array`
+ */
+export const init: (<Item>(array: readonly Item[]) => Item[]) = initStrict

--- a/packages/array/tail.ts
+++ b/packages/array/tail.ts
@@ -1,22 +1,13 @@
-interface Tail {
-  /**
-   * Get all but first items of an array
-   * @param array Input array
-   * @returns All but first items of `array`
-   */
-  <Tail extends any[]>(array: readonly [any, ...Tail]): Tail
-
-  /**
-   * Get all but first items of an array
-   * @param array Input array
-   * @returns All but first items of `array`
-   */
-  <Item>(array: readonly Item[]): Item[]
-}
+/**
+ * Get all but first items of an array
+ * @param array Input array
+ * @returns All but first items of `array`
+ */
+export const tail = <Item>(array: readonly Item[]): Item[] => array.slice(1)
 
 /**
  * Get all but first items of an array
  * @param array Input array
  * @returns All but first items of `array`
  */
-export const tail: Tail = ((array: any[]) => array.slice(1)) as any
+export const tailStrict: (<Tail extends any[]>(array: readonly [any, ...Tail]) => Tail) = tail as any

--- a/test/array/init.test.ts
+++ b/test/array/init.test.ts
@@ -1,9 +1,17 @@
-import { init } from '@tsfun/array'
+import { init, initStrict } from '@tsfun/array'
 
-it('when array is not empty', () => {
-  expect(init([0, 1, 2, 3])).toEqual([0, 1, 2])
+describe('init', () => {
+  it('when array is not empty', () => {
+    expect(init([0, 1, 2, 3])).toEqual([0, 1, 2])
+  })
+
+  it('when array is empty', () => {
+    expect(init([])).toEqual([])
+  })
 })
 
-it('when array is empty', () => {
-  expect(init([])).toEqual([])
+describe('initStrict', () => {
+  it('when array is not empty', () => {
+    expect(initStrict([0, 1, 2, 3])).toEqual([0, 1, 2])
+  })
 })

--- a/test/array/init.typecheck.ts
+++ b/test/array/init.typecheck.ts
@@ -1,6 +1,5 @@
 import assert from 'static-type-assert'
-import { init } from '@tsfun/array'
+import { initStrict } from '@tsfun/array'
 
-assert<[0, 1, 2]>(init([0, 1, 2, 3] as const))
-assert<[]>(init(['anything'] as const))
-assert<any[]>(init([])) // when user knows that input type is `[]`, precise return type is not that useful
+assert<[0, 1, 2]>(initStrict([0, 1, 2, 3] as const))
+assert<[]>(initStrict(['anything'] as const))

--- a/test/array/tail.test.ts
+++ b/test/array/tail.test.ts
@@ -1,9 +1,17 @@
-import { tail } from '@tsfun/array'
+import { tail, tailStrict } from '@tsfun/array'
 
-it('when array is not empty', () => {
-  expect(tail([0, 1, 2, 3])).toEqual([1, 2, 3])
+describe('tail', () => {
+  it('when array is not empty', () => {
+    expect(tail([0, 1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('when array is empty', () => {
+    expect(tail([])).toEqual([])
+  })
 })
 
-it('when array is empty', () => {
-  expect(tail([])).toEqual([])
+describe('tailStrict', () => {
+  it('when array is not empty', () => {
+    expect(tailStrict([0, 1, 2, 3])).toEqual([1, 2, 3])
+  })
 })

--- a/test/array/tail.typecheck.ts
+++ b/test/array/tail.typecheck.ts
@@ -1,6 +1,5 @@
 import assert from 'static-type-assert'
-import { tail } from '@tsfun/array'
+import { tailStrict } from '@tsfun/array'
 
-assert<[1, 2, 3]>(tail([0, 1, 2, 3] as const))
-assert<[]>(tail(['anything'] as const))
-assert<never[]>(tail([]))
+assert<[1, 2, 3]>(tailStrict([0, 1, 2, 3] as const))
+assert<[]>(tailStrict(['anything'] as const))


### PR DESCRIPTION
Non-strict versions for general use case, strict versions for precise tuple types.